### PR TITLE
Convert bytes to string for python3 compatibility.

### DIFF
--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -49,7 +49,7 @@ def matrix_snapshot():
     :return: Matrix List
     """
     response = urllib2.build_opener().open("https://api.travis-ci.org/builds/{0}".format(build_id)).read()
-    raw_json = json.loads(response)
+    raw_json = json.loads(response.decode('utf-8'))
     matrix_without_leader = [MatrixElement(element) for element in raw_json["matrix"]]
     return matrix_without_leader
 

--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from functools import reduce
 
 try:
     import urllib.request as urllib2


### PR DESCRIPTION
In python 3, `response` is a `bytes`, but `json.loads` requires a `str`. This casts to the appropriate type before parsing JSON.
