### PR TITLE
Use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - '3.4'
   - 'pypy'
   - 'pypy3'
+sudo: false # Use container-based infrastructure
 script:
   - echo "Doing something..."
   - echo "Done"


### PR DESCRIPTION
> Jobs running on container-based infrastructure:
> 1. start up faster
> 2. allow the use of caches for public repositories
> 3. disallow the use of sudo, setuid and setgid executables

http://docs.travis-ci.com/user/workers/container-based-infrastructure/
