### PR TITLE
Add support for Python 3

### DIFF
--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -3,7 +3,11 @@ import sys
 import json
 import time
 import logging
-from functools import reduce
+
+try:
+    from functools import reduce
+except ImportError:
+    pass
 
 try:
     import urllib.request as urllib2

--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -97,7 +97,7 @@ def get_token():
 
     req = urllib2.Request("{0}/auth/github".format(travis_entry), json.dumps(data).encode('utf-8'), headers)
     response = urllib2.urlopen(req).read()
-    travis_token = json.loads(response).get('access_token')
+    travis_token = json.loads(response.decode('utf-8')).get('access_token')
 
     return travis_token
 

--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -3,6 +3,7 @@ import sys
 import json
 import time
 import logging
+from functools import reduce
 
 try:
     import urllib.request as urllib2

--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -60,7 +60,7 @@ def matrix_snapshot(travis_token):
     headers = {'content-type': 'application/json', 'Authorization': 'token {}'.format(travis_token)}
     req = urllib2.Request("{0}/builds/{1}".format(travis_entry, build_id), headers=headers)
     response = urllib2.urlopen(req).read()
-    raw_json = json.loads(response)
+    raw_json = json.loads(response.decode('utf-8'))
     matrix_without_leader = [MatrixElement(job) for job in raw_json["matrix"] if not is_leader(job['number'])]
     return matrix_without_leader
 

--- a/travis_after_all.py
+++ b/travis_after_all.py
@@ -95,7 +95,7 @@ def get_token():
     data = {"github_token": gh_token}
     headers = {'content-type': 'application/json'}
 
-    req = urllib2.Request("{0}/auth/github".format(travis_entry), json.dumps(data), headers)
+    req = urllib2.Request("{0}/auth/github".format(travis_entry), json.dumps(data).encode('utf-8'), headers)
     response = urllib2.urlopen(req).read()
     travis_token = json.loads(response).get('access_token')
 


### PR DESCRIPTION
A couple of changes are required to make this script work with both legacy and current versions of Python. As of version 3.0, `reduce` is no longer a builtin and strings and bytes are no longer interchangeable. The correct import block is being added to address the former and the bytes returned through the response object are being covered to a string to address the latter.

This is an update to (and therefore replaces) #6.
