### PR TITLE
Don't leak secure variables to log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 after_success:
   - export GITHUB_TOKEN=${GITHUB_TOKEN_P1}${GITHUB_TOKEN_P2}
   - python travis_after_all.py
-  - export $(cat .to_export_back)
+  - export $(cat .to_export_back) > /dev/null
   - |
       if [ "$BUILD_LEADER" = "YES" ]; then
         if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
@@ -33,7 +33,7 @@ after_success:
 after_failure:
   - export GITHUB_TOKEN=${GITHUB_TOKEN_P1}${GITHUB_TOKEN_P2}
   - python travis_after_all.py
-  - export $(cat .to_export_back)
+  - export $(cat .to_export_back) > /dev/null
   - |
       if [ "$BUILD_LEADER" = "YES" ]; then
         if [ "$BUILD_AGGREGATE_STATUS" = "others_failed" ]; then


### PR DESCRIPTION
Fixes #24.

The old Travis log files can be deleted if necessary. 
